### PR TITLE
Update to PostCSS 6

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-.gitignore
-
-node_modules/
-npm-debug.log
-
-test.js
-.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: node_js
 node_js:
-  - "5"
-  - "4"
-  - "0.12"
+  - 4.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,6 @@
+## 2.0
+* Use PostCSS 6x
+* Use Node 4x syntax
+
 ## 1.0
 * Initial release

--- a/index.js
+++ b/index.js
@@ -5,15 +5,13 @@ module.exports = postcss.plugin('postcss-replace-overflow-wrap', function (opts)
     var method = opts.method || 'replace';
 
     return function (css, result) { // eslint-disable-line no-unused-vars
-        css.walkRules(function (rule) {
-            rule.walkDecls(function (decl, i) { // eslint-disable-line no-unused-vars
-                if (decl.prop === 'overflow-wrap') {
-                    decl.cloneBefore({ prop: 'word-wrap' });
-                    if (method === 'replace') {
-                        decl.remove();
-                    }
+        css.walkDecls(function (decl, i) { // eslint-disable-line no-unused-vars
+            if (decl.prop === 'overflow-wrap') {
+                decl.cloneBefore({ prop: 'word-wrap' });
+                if (method === 'replace') {
+                    decl.remove();
                 }
-            });
+            }
         });
     };
 });

--- a/index.js
+++ b/index.js
@@ -5,12 +5,10 @@ module.exports = postcss.plugin('postcss-replace-overflow-wrap', function (opts)
     var method = opts.method || 'replace';
 
     return function (css, result) { // eslint-disable-line no-unused-vars
-        css.walkDecls(function (decl, i) { // eslint-disable-line no-unused-vars
-            if (decl.prop === 'overflow-wrap') {
-                decl.cloneBefore({ prop: 'word-wrap' });
-                if (method === 'replace') {
-                    decl.remove();
-                }
+        css.walkDecls('overflow-wrap', function (decl, i) { // eslint-disable-line no-unused-vars
+            decl.cloneBefore({ prop: 'word-wrap' });
+            if (method === 'replace') {
+                decl.remove();
             }
         });
     };

--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ module.exports = postcss.plugin('postcss-replace-overflow-wrap', (opts) => {
     opts = opts || {};
     const method = opts.method || 'replace';
 
-    return (css, result) => { // eslint-disable-line no-unused-vars
-        css.walkDecls('overflow-wrap', (decl, i) => { // eslint-disable-line no-unused-vars
+    return (css) => {
+        css.walkDecls('overflow-wrap', (decl) => {
             decl.cloneBefore({ prop: 'word-wrap' });
             if (method === 'replace') {
                 decl.remove();

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
-var postcss = require('postcss');
+const postcss = require('postcss');
 
-module.exports = postcss.plugin('postcss-replace-overflow-wrap', function (opts) {
+module.exports = postcss.plugin('postcss-replace-overflow-wrap', (opts) => {
     opts = opts || {};
-    var method = opts.method || 'replace';
+    const method = opts.method || 'replace';
 
-    return function (css, result) { // eslint-disable-line no-unused-vars
-        css.walkDecls('overflow-wrap', function (decl, i) { // eslint-disable-line no-unused-vars
+    return (css, result) => { // eslint-disable-line no-unused-vars
+        css.walkDecls('overflow-wrap', (decl, i) => { // eslint-disable-line no-unused-vars
             decl.cloneBefore({ prop: 'word-wrap' });
             if (method === 'replace') {
                 decl.remove();

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
   },
   "homepage": "https://github.com/MattDiMu/postcss-replace-overflow-wrap",
   "dependencies": {
-    "postcss": "^5.0.16"
+    "postcss": "^6.0.1"
   },
   "devDependencies": {
-    "ava": "^0.14.0",
-    "eslint": "^2.1.0",
-    "eslint-config-postcss": "^2.0.0"
+    "ava": "^0.19.1",
+    "eslint": "^3.19.0",
+    "eslint-config-postcss": "^2.0.2"
   },
   "scripts": {
     "test": "ava && eslint *.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-replace-overflow-wrap",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "PostCSS plugin to replace overflow-wrap with word-wrap or optionally retain both declarations.",
   "keywords": [
     "postcss",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "url": "https://github.com/MattDiMu/postcss-replace-overflow-wrap/issues"
   },
   "homepage": "https://github.com/MattDiMu/postcss-replace-overflow-wrap",
+  "files": [
+    "index.js"
+  ],
   "dependencies": {
     "postcss": "^6.0.1"
   },


### PR DESCRIPTION
Hi @MattDiMu, this PR comes with a few changes, separated by commits:

- Changes from https://github.com/MattDiMu/postcss-replace-overflow-wrap/pull/3 (resolves #2)
- Updates to PostCSS v6
- Updates to Node 4x syntax (resolves #1)
- Whitelists index.js vs ignoring other files
- Removes unused vars
- Updates CHANGELOG and bumps package.json

You would then need to run `npm publish` and you’d be all set.