### PR TITLE
Add CSS Standard Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# PostCSS Replace Overflow Wrap [![Build Status][ci-img]][ci]
+# PostCSS Replace Overflow Wrap [![CSS Standard Status][css-img]][css] [![Build Status][ci-img]][ci]
 
 [PostCSS] plugin to replace overflow-wrap with word-wrap. May optionally retain both declarations.
 
 [PostCSS]: https://github.com/postcss/postcss
+[css-img]: https://jonathantneal.github.io/css-db/badge/css-text-overflow-wrap-property.svg
+[css]:     https://jonathantneal.github.io/css-db/#css-text-overflow-wrap-property
 [ci-img]:  https://travis-ci.org/MattDiMu/postcss-replace-overflow-wrap.svg
 [ci]:      https://travis-ci.org/MattDiMu/postcss-replace-overflow-wrap
 


### PR DESCRIPTION
Hey there. I’m just trying to get the word out that cssdb has badges to help users know the status of your CSS polyfill.

[cssdb](https://jonathantneal.github.io/css-db/) is a list I’m compiling of CSS features and their positions in the process of becoming implemented web standards.